### PR TITLE
Speedup, Prefixing, Boost Bug

### DIFF
--- a/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
+++ b/ur5_demo_descartes/include/ur5_demo_descartes/ur5_robot_model.h
@@ -26,17 +26,24 @@ const std::string UR5_TIP_LINK = "ee_link";
 class UR5RobotModel: public descartes_moveit::MoveitStateAdapter, public ur_kinematics::URKinematicsPlugin
 {
 public:
-  UR5RobotModel();
+  UR5RobotModel(const std::string& prefix = "");
   virtual ~UR5RobotModel();
 
   virtual bool initialize(const std::string &robot_description, const std::string& group_name,
                             const std::string& world_frame,const std::string& tcp_frame);
 
+  virtual bool initialize(robot_model::RobotModelConstPtr robot_model, const std::string& group_name,
+                          const std::string& world_frame, const std::string& tcp_frame);
+
+  virtual bool initializeHelper(const std::string& group_name, const std::string& world_frame,
+                                const std::string& tcp_frame);
+
   virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;
 
   descartes_core::Frame world_to_base_;// world to arm base
   descartes_core::Frame tool_to_tip_; // from arm tool to robot tool
-
+  std::string prefix_;
+  const std::string name_ = "ur5_robot_model";
 };
 
 } /* namespace ur5_demo_descartes */

--- a/ur5_demo_descartes/include/ur5_demo_descartes/ur_kin.h
+++ b/ur5_demo_descartes/include/ur5_demo_descartes/ur_kin.h
@@ -44,14 +44,13 @@
 #define SIGN(x) ( ( (x) > 0 ) - ( (x) < 0 ) )
 #define PI M_PI
 
-
 //#define UR5_PARAMS
-#define d1  0.089159
-#define a2 -0.42500
-#define a3 -0.39225
-#define d4  0.10915
-#define d5  0.09465
-#define d6  0.0823
+#define ur_kin_d1  0.089159
+#define ur_kin_a2 -0.42500
+#define ur_kin_a3 -0.39225
+#define ur_kin_d4  0.10915
+#define ur_kin_d5  0.09465
+#define ur_kin_d6  0.0823
 
 // These kinematics find the tranfrom from the base link to the end effector.
 // Though the raw D-H parameters specify a transform from the 0th link to the 6th link,
@@ -71,13 +70,14 @@
 //  0,  0,  0,  1
 
 namespace ur_kinematics {
-  // @param q       The 6 joint values 
+
+  // @param q       The 6 joint values
   // @param T       The 4x4 end effector pose in row-major ordering
   void forward(const double* q, double* T);
 
-  // @param q       The 6 joint values 
+  // @param q       The 6 joint values
   // @param Ti      The 4x4 link i pose in row-major ordering. If NULL, nothing is stored.
-  void forward_all(const double* q, double* T1, double* T2, double* T3, 
+  void forward_all(const double* q, double* T1, double* T2, double* T3,
                                     double* T4, double* T5, double* T6);
 
   // @param T       The 4x4 end effector pose in row-major ordering

--- a/ur5_demo_descartes/include/ur5_demo_descartes/ur_moveit_plugin.h
+++ b/ur5_demo_descartes/include/ur5_demo_descartes/ur_moveit_plugin.h
@@ -115,7 +115,7 @@ namespace ur_kinematics
     /**
 * @brief Default constructor
 */
-    URKinematicsPlugin();
+    URKinematicsPlugin(const std::string& prefix);
 
     virtual bool getPositionIK(const geometry_msgs::Pose &ik_pose,
                                const std::vector<double> &ik_seed_state,
@@ -160,6 +160,12 @@ namespace ur_kinematics
                                std::vector<geometry_msgs::Pose> &poses) const;
 
     virtual bool initialize(const std::string &robot_description,
+                            const std::string &group_name,
+                            const std::string &base_name,
+                            const std::string &tip_name,
+                            double search_discretization);
+
+    virtual bool initialize(robot_model::RobotModelConstPtr robot_model,
                             const std::string &group_name,
                             const std::string &base_name,
                             const std::string &tip_name,
@@ -252,7 +258,7 @@ namespace ur_kinematics
 
     mutable random_numbers::RandomNumberGenerator random_number_generator_;
 
-    robot_model::RobotModelPtr robot_model_;
+    robot_model::RobotModelConstPtr robot_model_;
 
     robot_state::RobotStatePtr state_, state_2_;
 
@@ -261,7 +267,7 @@ namespace ur_kinematics
 
     // Storage required for when the set of redundant joints is reset
     bool position_ik_; //whether this solver is only being used for position ik
-    robot_model::JointModelGroup* joint_model_group_;
+    const robot_model::JointModelGroup* joint_model_group_;
     double max_solver_iterations_;
     double epsilon_;
     std::vector<kdl_kinematics_plugin::JointMimic> mimic_joints_;

--- a/ur5_demo_descartes/src/ur_kin.cpp
+++ b/ur5_demo_descartes/src/ur_kin.cpp
@@ -8,33 +8,33 @@ namespace ur_kinematics {
     double s3 = sin(*q), c3 = cos(*q); q234 += *q; q++;
     q234 += *q; q++;
     double s5 = sin(*q), c5 = cos(*q); q++;
-    double s6 = sin(*q), c6 = cos(*q); 
+    double s6 = sin(*q), c6 = cos(*q);
     double s234 = sin(q234), c234 = cos(q234);
     *T = ((c1*c234-s1*s234)*s5)/2.0 - c5*s1 + ((c1*c234+s1*s234)*s5)/2.0; T++;
-    *T = (c6*(s1*s5 + ((c1*c234-s1*s234)*c5)/2.0 + ((c1*c234+s1*s234)*c5)/2.0) - 
+    *T = (c6*(s1*s5 + ((c1*c234-s1*s234)*c5)/2.0 + ((c1*c234+s1*s234)*c5)/2.0) -
           (s6*((s1*c234+c1*s234) - (s1*c234-c1*s234)))/2.0); T++;
-    *T = (-(c6*((s1*c234+c1*s234) - (s1*c234-c1*s234)))/2.0 - 
+    *T = (-(c6*((s1*c234+c1*s234) - (s1*c234-c1*s234)))/2.0 -
           s6*(s1*s5 + ((c1*c234-s1*s234)*c5)/2.0 + ((c1*c234+s1*s234)*c5)/2.0)); T++;
-    *T = ((d5*(s1*c234-c1*s234))/2.0 - (d5*(s1*c234+c1*s234))/2.0 - 
-          d4*s1 + (d6*(c1*c234-s1*s234)*s5)/2.0 + (d6*(c1*c234+s1*s234)*s5)/2.0 - 
-          a2*c1*c2 - d6*c5*s1 - a3*c1*c2*c3 + a3*c1*s2*s3); T++;
+    *T = ((ur_kin_d5*(s1*c234-c1*s234))/2.0 - (ur_kin_d5*(s1*c234+c1*s234))/2.0 -
+          ur_kin_d4*s1 + (ur_kin_d6*(c1*c234-s1*s234)*s5)/2.0 + (ur_kin_d6*(c1*c234+s1*s234)*s5)/2.0 -
+          ur_kin_a2*c1*c2 - ur_kin_d6*c5*s1 - ur_kin_a3*c1*c2*c3 + ur_kin_a3*c1*s2*s3); T++;
     *T = c1*c5 + ((s1*c234+c1*s234)*s5)/2.0 + ((s1*c234-c1*s234)*s5)/2.0; T++;
-    *T = (c6*(((s1*c234+c1*s234)*c5)/2.0 - c1*s5 + ((s1*c234-c1*s234)*c5)/2.0) + 
+    *T = (c6*(((s1*c234+c1*s234)*c5)/2.0 - c1*s5 + ((s1*c234-c1*s234)*c5)/2.0) +
           s6*((c1*c234-s1*s234)/2.0 - (c1*c234+s1*s234)/2.0)); T++;
-    *T = (c6*((c1*c234-s1*s234)/2.0 - (c1*c234+s1*s234)/2.0) - 
+    *T = (c6*((c1*c234-s1*s234)/2.0 - (c1*c234+s1*s234)/2.0) -
           s6*(((s1*c234+c1*s234)*c5)/2.0 - c1*s5 + ((s1*c234-c1*s234)*c5)/2.0)); T++;
-    *T = ((d5*(c1*c234-s1*s234))/2.0 - (d5*(c1*c234+s1*s234))/2.0 + d4*c1 + 
-          (d6*(s1*c234+c1*s234)*s5)/2.0 + (d6*(s1*c234-c1*s234)*s5)/2.0 + d6*c1*c5 - 
-          a2*c2*s1 - a3*c2*c3*s1 + a3*s1*s2*s3); T++;
+    *T = ((ur_kin_d5*(c1*c234-s1*s234))/2.0 - (ur_kin_d5*(c1*c234+s1*s234))/2.0 + ur_kin_d4*c1 +
+          (ur_kin_d6*(s1*c234+c1*s234)*s5)/2.0 + (ur_kin_d6*(s1*c234-c1*s234)*s5)/2.0 + ur_kin_d6*c1*c5 -
+          ur_kin_a2*c2*s1 - ur_kin_a3*c2*c3*s1 + ur_kin_a3*s1*s2*s3); T++;
     *T = ((c234*c5-s234*s5)/2.0 - (c234*c5+s234*s5)/2.0); T++;
     *T = ((s234*c6-c234*s6)/2.0 - (s234*c6+c234*s6)/2.0 - s234*c5*c6); T++;
     *T = (s234*c5*s6 - (c234*c6+s234*s6)/2.0 - (c234*c6-s234*s6)/2.0); T++;
-    *T = (d1 + (d6*(c234*c5-s234*s5))/2.0 + a3*(s2*c3+c2*s3) + a2*s2 - 
-         (d6*(c234*c5+s234*s5))/2.0 - d5*c234); T++;
+    *T = (ur_kin_d1 + (ur_kin_d6*(c234*c5-s234*s5))/2.0 + ur_kin_a3*(s2*c3+c2*s3) + ur_kin_a2*s2 -
+         (ur_kin_d6*(c234*c5+s234*s5))/2.0 - ur_kin_d5*c234); T++;
     *T = 0.0; T++; *T = 0.0; T++; *T = 0.0; T++; *T = 1.0;
   }
 
-  void forward_all(const double* q, double* T1, double* T2, double* T3, 
+  void forward_all(const double* q, double* T1, double* T2, double* T3,
                                     double* T4, double* T5, double* T6) {
     double s1 = sin(*q), c1 = cos(*q); q++; // q1
     double q23 = *q, q234 = *q, s2 = sin(*q), c2 = cos(*q); q++; // q2
@@ -57,7 +57,7 @@ namespace ur_kinematics {
       *T1 =       0; T1++;
       *T1 = 1; T1++;
       *T1 = 0; T1++;
-      *T1 =d1; T1++;
+      *T1 =ur_kin_d1; T1++;
       *T1 =       0; T1++;
       *T1 = 0; T1++;
       *T1 = 0; T1++;
@@ -68,15 +68,15 @@ namespace ur_kinematics {
       *T2 = c1*c2; T2++;
       *T2 = -c1*s2; T2++;
       *T2 = s1; T2++;
-      *T2 =a2*c1*c2; T2++;
+      *T2 =ur_kin_a2*c1*c2; T2++;
       *T2 = c2*s1; T2++;
       *T2 = -s1*s2; T2++;
       *T2 = -c1; T2++;
-      *T2 =a2*c2*s1; T2++;
+      *T2 =ur_kin_a2*c2*s1; T2++;
       *T2 =         s2; T2++;
       *T2 = c2; T2++;
       *T2 = 0; T2++;
-      *T2 =   d1 + a2*s2; T2++;
+      *T2 =   ur_kin_d1 + ur_kin_a2*s2; T2++;
       *T2 =               0; T2++;
       *T2 = 0; T2++;
       *T2 = 0; T2++;
@@ -87,15 +87,15 @@ namespace ur_kinematics {
       *T3 = c23*c1; T3++;
       *T3 = -s23*c1; T3++;
       *T3 = s1; T3++;
-      *T3 =c1*(a3*c23 + a2*c2); T3++;
+      *T3 =c1*(ur_kin_a3*c23 + ur_kin_a2*c2); T3++;
       *T3 = c23*s1; T3++;
       *T3 = -s23*s1; T3++;
       *T3 = -c1; T3++;
-      *T3 =s1*(a3*c23 + a2*c2); T3++;
+      *T3 =s1*(ur_kin_a3*c23 + ur_kin_a2*c2); T3++;
       *T3 =         s23; T3++;
       *T3 = c23; T3++;
       *T3 = 0; T3++;
-      *T3 =     d1 + a3*s23 + a2*s2; T3++;
+      *T3 =     ur_kin_d1 + ur_kin_a3*s23 + ur_kin_a2*s2; T3++;
       *T3 =                    0; T3++;
       *T3 = 0; T3++;
       *T3 = 0; T3++;
@@ -106,15 +106,15 @@ namespace ur_kinematics {
       *T4 = c234*c1; T4++;
       *T4 = s1; T4++;
       *T4 = s234*c1; T4++;
-      *T4 =c1*(a3*c23 + a2*c2) + d4*s1; T4++;
+      *T4 =c1*(ur_kin_a3*c23 + ur_kin_a2*c2) + ur_kin_d4*s1; T4++;
       *T4 = c234*s1; T4++;
       *T4 = -c1; T4++;
       *T4 = s234*s1; T4++;
-      *T4 =s1*(a3*c23 + a2*c2) - d4*c1; T4++;
+      *T4 =s1*(ur_kin_a3*c23 + ur_kin_a2*c2) - ur_kin_d4*c1; T4++;
       *T4 =         s234; T4++;
       *T4 = 0; T4++;
       *T4 = -c234; T4++;
-      *T4 =                  d1 + a3*s23 + a2*s2; T4++;
+      *T4 =                  ur_kin_d1 + ur_kin_a3*s23 + ur_kin_a2*s2; T4++;
       *T4 =                         0; T4++;
       *T4 = 0; T4++;
       *T4 = 0; T4++;
@@ -125,15 +125,15 @@ namespace ur_kinematics {
       *T5 = s1*s5 + c234*c1*c5; T5++;
       *T5 = -s234*c1; T5++;
       *T5 = c5*s1 - c234*c1*s5; T5++;
-      *T5 =c1*(a3*c23 + a2*c2) + d4*s1 + d5*s234*c1; T5++;
+      *T5 =c1*(ur_kin_a3*c23 + ur_kin_a2*c2) + ur_kin_d4*s1 + ur_kin_d5*s234*c1; T5++;
       *T5 = c234*c5*s1 - c1*s5; T5++;
       *T5 = -s234*s1; T5++;
       *T5 = - c1*c5 - c234*s1*s5; T5++;
-      *T5 =s1*(a3*c23 + a2*c2) - d4*c1 + d5*s234*s1; T5++;
+      *T5 =s1*(ur_kin_a3*c23 + ur_kin_a2*c2) - ur_kin_d4*c1 + ur_kin_d5*s234*s1; T5++;
       *T5 =                           s234*c5; T5++;
       *T5 = c234; T5++;
       *T5 = -s234*s5; T5++;
-      *T5 =                          d1 + a3*s23 + a2*s2 - d5*c234; T5++;
+      *T5 =                          ur_kin_d1 + ur_kin_a3*s23 + ur_kin_a2*s2 - ur_kin_d5*c234; T5++;
       *T5 =                                                   0; T5++;
       *T5 = 0; T5++;
       *T5 = 0; T5++;
@@ -144,15 +144,15 @@ namespace ur_kinematics {
       *T6 =   c6*(s1*s5 + c234*c1*c5) - s234*c1*s6; T6++;
       *T6 = - s6*(s1*s5 + c234*c1*c5) - s234*c1*c6; T6++;
       *T6 = c5*s1 - c234*c1*s5; T6++;
-      *T6 =d6*(c5*s1 - c234*c1*s5) + c1*(a3*c23 + a2*c2) + d4*s1 + d5*s234*c1; T6++;
+      *T6 =ur_kin_d6*(c5*s1 - c234*c1*s5) + c1*(ur_kin_a3*c23 + ur_kin_a2*c2) + ur_kin_d4*s1 + ur_kin_d5*s234*c1; T6++;
       *T6 = - c6*(c1*s5 - c234*c5*s1) - s234*s1*s6; T6++;
       *T6 = s6*(c1*s5 - c234*c5*s1) - s234*c6*s1; T6++;
       *T6 = - c1*c5 - c234*s1*s5; T6++;
-      *T6 =s1*(a3*c23 + a2*c2) - d4*c1 - d6*(c1*c5 + c234*s1*s5) + d5*s234*s1; T6++;
+      *T6 =s1*(ur_kin_a3*c23 + ur_kin_a2*c2) - ur_kin_d4*c1 - ur_kin_d6*(c1*c5 + c234*s1*s5) + ur_kin_d5*s234*s1; T6++;
       *T6 =                                       c234*s6 + s234*c5*c6; T6++;
       *T6 = c234*c6 - s234*c5*s6; T6++;
       *T6 = -s234*s5; T6++;
-      *T6 =                                                      d1 + a3*s23 + a2*s2 - d5*c234 - d6*s234*s5; T6++;
+      *T6 =                                                      ur_kin_d1 + ur_kin_a3*s23 + ur_kin_a2*s2 - ur_kin_d5*c234 - ur_kin_d6*s234*s5; T6++;
       *T6 =                                                                                                   0; T6++;
       *T6 = 0; T6++;
       *T6 = 0; T6++;
@@ -162,22 +162,22 @@ namespace ur_kinematics {
 
   int inverse(const double* T, double* q_sols, double q6_des) {
     int num_sols = 0;
-    double T02 = -*T; T++; double T00 =  *T; T++; double T01 =  *T; T++; double T03 = -*T; T++; 
-    double T12 = -*T; T++; double T10 =  *T; T++; double T11 =  *T; T++; double T13 = -*T; T++; 
+    double T02 = -*T; T++; double T00 =  *T; T++; double T01 =  *T; T++; double T03 = -*T; T++;
+    double T12 = -*T; T++; double T10 =  *T; T++; double T11 =  *T; T++; double T13 = -*T; T++;
     double T22 =  *T; T++; double T20 = -*T; T++; double T21 = -*T; T++; double T23 =  *T;
 
     ////////////////////////////// shoulder rotate joint (q1) //////////////////////////////
     double q1[2];
     {
-      double A = d6*T12 - T13;
-      double B = d6*T02 - T03;
+      double A = ur_kin_d6*T12 - T13;
+      double B = ur_kin_d6*T02 - T03;
       double R = A*A + B*B;
       if(fabs(A) < ZERO_THRESH) {
         double div;
-        if(fabs(fabs(d4) - fabs(B)) < ZERO_THRESH)
-          div = -SIGN(d4)*SIGN(B);
+        if(fabs(fabs(ur_kin_d4) - fabs(B)) < ZERO_THRESH)
+          div = -SIGN(ur_kin_d4)*SIGN(B);
         else
-          div = -d4/B;
+          div = -ur_kin_d4/B;
         double arcsin = asin(div);
         if(fabs(arcsin) < ZERO_THRESH)
           arcsin = 0.0;
@@ -189,19 +189,19 @@ namespace ur_kinematics {
       }
       else if(fabs(B) < ZERO_THRESH) {
         double div;
-        if(fabs(fabs(d4) - fabs(A)) < ZERO_THRESH)
-          div = SIGN(d4)*SIGN(A);
+        if(fabs(fabs(ur_kin_d4) - fabs(A)) < ZERO_THRESH)
+          div = SIGN(ur_kin_d4)*SIGN(A);
         else
-          div = d4/A;
+          div = ur_kin_d4/A;
         double arccos = acos(div);
         q1[0] = arccos;
         q1[1] = 2.0*PI - arccos;
       }
-      else if(d4*d4 > R) {
+      else if(ur_kin_d4*ur_kin_d4 > R) {
         return num_sols;
       }
       else {
-        double arccos = acos(d4 / sqrt(R)) ;
+        double arccos = acos(ur_kin_d4 / sqrt(R)) ;
         double arctan = atan2(-B, A);
         double pos = arccos + arctan;
         double neg = -arccos + arctan;
@@ -214,7 +214,7 @@ namespace ur_kinematics {
         else
           q1[0] = 2.0*PI + pos;
         if(neg >= 0.0)
-          q1[1] = neg; 
+          q1[1] = neg;
         else
           q1[1] = 2.0*PI + neg;
       }
@@ -225,12 +225,12 @@ namespace ur_kinematics {
     double q5[2][2];
     {
       for(int i=0;i<2;i++) {
-        double numer = (T03*sin(q1[i]) - T13*cos(q1[i])-d4);
+        double numer = (T03*sin(q1[i]) - T13*cos(q1[i])-ur_kin_d4);
         double div;
-        if(fabs(fabs(numer) - fabs(d6)) < ZERO_THRESH)
-          div = SIGN(numer) * SIGN(d6);
+        if(fabs(fabs(numer) - fabs(ur_kin_d6)) < ZERO_THRESH)
+          div = SIGN(numer) * SIGN(ur_kin_d6);
         else
-          div = numer / d6;
+          div = numer / ur_kin_d6;
         double arccos = acos(div);
         q5[i][0] = arccos;
         q5[i][1] = 2.0*PI - arccos;
@@ -248,7 +248,7 @@ namespace ur_kinematics {
           if(fabs(s5) < ZERO_THRESH)
             q6 = q6_des;
           else {
-            q6 = atan2(SIGN(s5)*-(T01*s1 - T11*c1), 
+            q6 = atan2(SIGN(s5)*-(T01*s1 - T11*c1),
                        SIGN(s5)*(T00*s1 - T10*c1));
             if(fabs(q6) < ZERO_THRESH)
               q6 = 0.0;
@@ -262,11 +262,11 @@ namespace ur_kinematics {
           double c6 = cos(q6), s6 = sin(q6);
           double x04x = -s5*(T02*c1 + T12*s1) - c5*(s6*(T01*c1 + T11*s1) - c6*(T00*c1 + T10*s1));
           double x04y = c5*(T20*c6 - T21*s6) - T22*s5;
-          double p13x = d5*(s6*(T00*c1 + T10*s1) + c6*(T01*c1 + T11*s1)) - d6*(T02*c1 + T12*s1) + 
+          double p13x = ur_kin_d5*(s6*(T00*c1 + T10*s1) + c6*(T01*c1 + T11*s1)) - ur_kin_d6*(T02*c1 + T12*s1) +
                         T03*c1 + T13*s1;
-          double p13y = T23 - d1 - d6*T22 + d5*(T21*c6 + T20*s6);
+          double p13y = T23 - ur_kin_d1 - ur_kin_d6*T22 + ur_kin_d5*(T21*c6 + T20*s6);
 
-          double c3 = (p13x*p13x + p13y*p13y - a2*a2 - a3*a3) / (2.0*a2*a3);
+          double c3 = (p13x*p13x + p13y*p13y - ur_kin_a2*ur_kin_a2 - ur_kin_a3*ur_kin_a3) / (2.0*ur_kin_a2*ur_kin_a3);
           if(fabs(fabs(c3) - 1.0) < ZERO_THRESH)
             c3 = SIGN(c3);
           else if(fabs(c3) > 1.0) {
@@ -276,9 +276,9 @@ namespace ur_kinematics {
           double arccos = acos(c3);
           q3[0] = arccos;
           q3[1] = 2.0*PI - arccos;
-          double denom = a2*a2 + a3*a3 + 2*a2*a3*c3;
+          double denom = ur_kin_a2*ur_kin_a2 + ur_kin_a3*ur_kin_a3 + 2*ur_kin_a2*ur_kin_a3*c3;
           double s3 = sin(arccos);
-          double A = (a2 + a3*c3), B = a3*s3;
+          double A = (ur_kin_a2 + ur_kin_a3*c3), B = ur_kin_a3*s3;
           q2[0] = atan2((A*p13y - B*p13x) / denom, (A*p13x + B*p13y) / denom);
           q2[1] = atan2((A*p13y + B*p13x) / denom, (A*p13x - B*p13y) / denom);
           double c23_0 = cos(q2[0]+q3[0]);
@@ -295,9 +295,9 @@ namespace ur_kinematics {
             if(fabs(q4[k]) < ZERO_THRESH)
               q4[k] = 0.0;
             else if(q4[k] < 0.0) q4[k] += 2.0*PI;
-            q_sols[num_sols*6+0] = q1[i];    q_sols[num_sols*6+1] = q2[k]; 
-            q_sols[num_sols*6+2] = q3[k];    q_sols[num_sols*6+3] = q4[k]; 
-            q_sols[num_sols*6+4] = q5[i][j]; q_sols[num_sols*6+5] = q6; 
+            q_sols[num_sols*6+0] = q1[i];    q_sols[num_sols*6+1] = q2[k];
+            q_sols[num_sols*6+2] = q3[k];    q_sols[num_sols*6+3] = q4[k];
+            q_sols[num_sols*6+4] = q5[i][j]; q_sols[num_sols*6+5] = q6;
             num_sols++;
           }
 
@@ -402,8 +402,8 @@ int main(int argc, char* argv[])
   double q_sols[8*6];
   int num_sols;
   num_sols = inverse(T, q_sols);
-  for(int i=0;i<num_sols;i++) 
-    printf("%1.6f %1.6f %1.6f %1.6f %1.6f %1.6f\n", 
+  for(int i=0;i<num_sols;i++)
+    printf("%1.6f %1.6f %1.6f %1.6f %1.6f %1.6f\n",
        q_sols[i*6+0], q_sols[i*6+1], q_sols[i*6+2], q_sols[i*6+3], q_sols[i*6+4], q_sols[i*6+5]);
   for(int i=0;i<=4;i++)
     printf("%f ", PI/2.0*i);


### PR DESCRIPTION
Includes:
- Jonathan's UR5 prefixing of joint name (for Hilgendorf)
- Optional initialize() function that takes a moveit::RobotModel instead of robot_description, see https://github.com/ros-industrial-consortium/descartes/pull/170
- Conflicting compiler define names with [boost::bind](http://www.boost.org/doc/libs/1_41_0/libs/bind/bind.html) - it uses the vars a2 etc so i prefixed all the vars
